### PR TITLE
event interest level categories

### DIFF
--- a/less/index.less
+++ b/less/index.less
@@ -2,3 +2,4 @@
 
 @import "main";
 @import "singleOrg";
+@import "saveEventModal";

--- a/less/saveEventModal.less
+++ b/less/saveEventModal.less
@@ -1,10 +1,3 @@
-* {
-  font-family: "Gothic A1", sans-serif;
-}
-.slick-prev:before,
-.slick-next:before {
-  color: black !important;
-}
 .save-event-modal {
   width: 40rem;
   text-align: center;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-router-dom": "^6.4.2",
         "react-scripts": "5.0.1",
         "react-slick": "^0.29.0",
+        "reactjs-popup": "^2.0.5",
         "slick-carousel": "^1.8.1",
         "web-vitals": "^2.1.4"
       },
@@ -14544,6 +14545,18 @@
         "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/reactjs-popup": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/reactjs-popup/-/reactjs-popup-2.0.5.tgz",
+      "integrity": "sha512-b5hv9a6aGsHEHXFAgPO5s1Jw1eSkopueyUVxQewGdLgqk2eW0IVXZrPRpHR629YcgIpC2oxtX8OOZ8a7bQJbxA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -27600,6 +27613,12 @@
         "lodash.debounce": "^4.0.8",
         "resize-observer-polyfill": "^1.5.0"
       }
+    },
+    "reactjs-popup": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/reactjs-popup/-/reactjs-popup-2.0.5.tgz",
+      "integrity": "sha512-b5hv9a6aGsHEHXFAgPO5s1Jw1eSkopueyUVxQewGdLgqk2eW0IVXZrPRpHR629YcgIpC2oxtX8OOZ8a7bQJbxA==",
+      "requires": {}
     },
     "read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-router-dom": "^6.4.2",
     "react-scripts": "5.0.1",
     "react-slick": "^0.29.0",
+    "reactjs-popup": "^2.0.5",
     "slick-carousel": "^1.8.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ import Account from "./Components/Account/Account";
 import EditAccount from "./Components/Account/EditAccount";
 import Navbar from "./Components/Navbar";
 import SingleOrg from "./Components/SingleOrg/SingleOrg";
-import SingleEvent from "./Components/SingleEvent";
+import SingleEvent from "./Components/SingleEvent/SingleEvent";
 import Discover from "./Components/Discover";
 import ForYouPage from "./Components/ForYou/ForYouPage";
 import SavedEventPage from "./Components/SavedEvents/SavedEventPage";

--- a/src/Components/SavedEvents/SavedEventInfo.js
+++ b/src/Components/SavedEvents/SavedEventInfo.js
@@ -32,7 +32,7 @@ export default function SavedEventInfo(props) {
               <p>{entry.Events.date}</p>
               {entry.Events.time && <p>{entry.Events.time}</p>}
               <button onClick={() => props.handleRemove(entry.eventId)}>
-                Remove
+                Remove from Calendar
               </button>
             </div>
           ))}

--- a/src/Components/SingleEvent/SaveEventPopup.js
+++ b/src/Components/SingleEvent/SaveEventPopup.js
@@ -23,7 +23,9 @@ export default function SaveEvent(props) {
     <Popup
       trigger={
         <button className="button">
-          {props.alreadySaved ? "Edit Interest Level" : "Save Event"}
+          {props.alreadySaved
+            ? `Edit Interest Level (${props.currentInterestLevel})`
+            : "Save Event"}
         </button>
       }
       modal

--- a/src/Components/SingleEvent/SaveEventPopup.js
+++ b/src/Components/SingleEvent/SaveEventPopup.js
@@ -6,6 +6,19 @@ import UpdateEvent from "../../innerComponents/updateEvent";
 import Popup from "reactjs-popup";
 
 export default function SaveEvent(props) {
+  // const [currentInterestLevel, setCurrentInterestLevel] = useState("");
+
+  // const handleInterest = useCallback(
+  //   async () => {
+  //     setCurrentInterestLevel(props.currentInterestLevel)
+  //   },
+  //   [props.currentInterestLevel]
+  // );
+
+  // useEffect(() => {
+  //   handleInterest();
+  // }, [handleInterest]);
+
   return (
     <Popup
       trigger={
@@ -24,7 +37,10 @@ export default function SaveEvent(props) {
           </button>
           <div className="header"> Want to gogh to this event? </div>
           <div className="content">
-            {" "}
+            {props.currentInterestLevel && (
+              <span>You are currently: {props.currentInterestLevel}</span>
+            )}
+            <br />
             Indicate your level of interest.
             <br />
             See a calendar view of your saved events on the Plan page!

--- a/src/Components/SingleEvent/SaveEventPopup.js
+++ b/src/Components/SingleEvent/SaveEventPopup.js
@@ -1,24 +1,7 @@
-import React, { useEffect, useCallback, useState } from "react";
-import { useParams } from "react-router-dom";
-import { supabase } from "../../supabaseClient";
-import { Link } from "react-router-dom";
-import UpdateEvent from "../../innerComponents/updateEvent";
+import React from "react";
 import Popup from "reactjs-popup";
 
-export default function SaveEvent(props) {
-  // const [currentInterestLevel, setCurrentInterestLevel] = useState("");
-
-  // const handleInterest = useCallback(
-  //   async () => {
-  //     setCurrentInterestLevel(props.currentInterestLevel)
-  //   },
-  //   [props.currentInterestLevel]
-  // );
-
-  // useEffect(() => {
-  //   handleInterest();
-  // }, [handleInterest]);
-
+export default function SaveEventPopup(props) {
   return (
     <Popup
       trigger={

--- a/src/Components/SingleEvent/SaveEventPopup.js
+++ b/src/Components/SingleEvent/SaveEventPopup.js
@@ -38,12 +38,12 @@ export default function SaveEvent(props) {
           <div className="header"> Want to gogh to this event? </div>
           <div className="content">
             {props.currentInterestLevel && (
-              <span>You are currently: {props.currentInterestLevel}</span>
+              <span>
+                You are currently: {props.currentInterestLevel}
+                <br />
+              </span>
             )}
-            <br />
-            Indicate your level of interest.
-            <br />
-            See a calendar view of your saved events on the Plan page!
+            {props.alreadySaved ? "Edit" : "Indicate"} your preference.
           </div>
           <div className="actions">
             <button
@@ -62,6 +62,10 @@ export default function SaveEvent(props) {
             >
               Attending
             </button>
+            <div className="content">
+              <br />
+              See a calendar view of your saved events on the Plan page!
+            </div>
           </div>
         </div>
       )}

--- a/src/Components/SingleEvent/SaveEventPopup.js
+++ b/src/Components/SingleEvent/SaveEventPopup.js
@@ -22,6 +22,31 @@ export default function SaveEvent(props) {
           <button className="close" onClick={close}>
             &times;
           </button>
+          <div className="header"> Want to gogh to this event? </div>
+          <div className="content">
+            {" "}
+            Indicate your level of interest.
+            <br />
+            See a calendar view of your saved events on the Plan page!
+          </div>
+          <div className="actions">
+            <button
+              onClick={() => {
+                props.handleSaveEvent("interested");
+                close();
+              }}
+            >
+              Interested
+            </button>
+            <button
+              onClick={() => {
+                props.handleSaveEvent("attending");
+                close();
+              }}
+            >
+              Attending
+            </button>
+          </div>
         </div>
       )}
     </Popup>

--- a/src/Components/SingleEvent/SaveEventPopup.js
+++ b/src/Components/SingleEvent/SaveEventPopup.js
@@ -1,0 +1,9 @@
+import React, { useEffect, useCallback, useState } from "react";
+import { useParams } from "react-router-dom";
+import { supabase } from "../../supabaseClient";
+import { Link } from "react-router-dom";
+import UpdateEvent from "../../innerComponents/updateEvent";
+
+export default function SaveEvent(props) {
+  return <button onClick={props.handleSaveEvent}>Save Event</button>;
+}

--- a/src/Components/SingleEvent/SaveEventPopup.js
+++ b/src/Components/SingleEvent/SaveEventPopup.js
@@ -3,7 +3,27 @@ import { useParams } from "react-router-dom";
 import { supabase } from "../../supabaseClient";
 import { Link } from "react-router-dom";
 import UpdateEvent from "../../innerComponents/updateEvent";
+import Popup from "reactjs-popup";
 
 export default function SaveEvent(props) {
-  return <button onClick={props.handleSaveEvent}>Save Event</button>;
+  return (
+    <Popup
+      trigger={
+        <button className="button">
+          {props.alreadySaved ? "Edit Interest Level" : "Save Event"}
+        </button>
+      }
+      modal
+      nested
+      className="save-event-modal"
+    >
+      {(close) => (
+        <div className="save-event-modal">
+          <button className="close" onClick={close}>
+            &times;
+          </button>
+        </div>
+      )}
+    </Popup>
+  );
 }

--- a/src/Components/SingleEvent/SingleEvent.js
+++ b/src/Components/SingleEvent/SingleEvent.js
@@ -53,7 +53,6 @@ export default function SingleEvent() {
       } else {
         setAlreadySaved(false);
       }
-      // user_added_events ? setAlreadySaved(true) : setAlreadySaved(false);
     }
   }, [authUserId, id]);
 

--- a/src/Components/SingleEvent/SingleEvent.js
+++ b/src/Components/SingleEvent/SingleEvent.js
@@ -13,6 +13,7 @@ export default function SingleEvent() {
   const [relatedOrgName, setRelatedOrgName] = useState("");
   const [error, setError] = useState("");
   const [alreadySaved, setAlreadySaved] = useState(false);
+  const [currentInterestLevel, setCurrentInterestLevel] = useState("");
 
   const fetchSingleEvent = useCallback(async () => {
     let { data: Events, error } = await supabase
@@ -46,7 +47,13 @@ export default function SingleEvent() {
         .eq("userId", authUserId)
         .eq("eventId", id)
         .single();
-      user_added_events ? setAlreadySaved(true) : setAlreadySaved(false);
+      if (user_added_events) {
+        setAlreadySaved(true);
+        setCurrentInterestLevel(user_added_events.interest_level);
+      } else {
+        setAlreadySaved(false);
+      }
+      // user_added_events ? setAlreadySaved(true) : setAlreadySaved(false);
     }
   }, [authUserId, id]);
 
@@ -57,12 +64,15 @@ export default function SingleEvent() {
 
   const handleSaveEvent = useCallback(
     async (interestLevel) => {
-      const { error } = await supabase
+      const { data, error } = await supabase
         .from("user_added_events")
         .upsert([
           { userId: authUserId, eventId: id, interest_level: interestLevel },
-        ]);
+        ])
+        .single()
+        .select();
       if (!error) setAlreadySaved(true);
+      setCurrentInterestLevel(data.interest_level);
     },
     [authUserId, id]
   );
@@ -74,6 +84,7 @@ export default function SingleEvent() {
       .eq("userId", authUserId)
       .eq("eventId", id);
     if (!error) setAlreadySaved(false);
+    setCurrentInterestLevel("");
   }, [authUserId, id]);
 
   let { title, description, date, time, location, imageUrl, OrgId } =
@@ -117,6 +128,7 @@ export default function SingleEvent() {
                   handleSaveEvent={handleSaveEvent}
                   handleRemoveEvent={handleRemoveEvent}
                   alreadySaved={false}
+                  currentInterestLevel={currentInterestLevel}
                 />
               ) : (
                 <div>
@@ -125,6 +137,7 @@ export default function SingleEvent() {
                     handleSaveEvent={handleSaveEvent}
                     handleRemoveEvent={handleRemoveEvent}
                     alreadySaved={true}
+                    currentInterestLevel={currentInterestLevel}
                   />
                   <button onClick={handleRemoveEvent}>
                     Remove Event from Profile
@@ -144,6 +157,3 @@ export default function SingleEvent() {
     </div>
   );
 }
-
-// if event is not already saved, show button that lets users save events
-//

--- a/src/Components/SingleEvent/SingleEvent.js
+++ b/src/Components/SingleEvent/SingleEvent.js
@@ -55,12 +55,17 @@ export default function SingleEvent() {
     handleSavedStatus();
   }, [fetchSingleEvent, handleSavedStatus]);
 
-  const handleSaveEvent = useCallback(async () => {
-    const { error } = await supabase
-      .from("user_added_events")
-      .insert([{ userId: authUserId, eventId: id }]);
-    if (!error) setAlreadySaved(true);
-  }, [authUserId, id]);
+  const handleSaveEvent = useCallback(
+    async (interestLevel) => {
+      const { error } = await supabase
+        .from("user_added_events")
+        .insert([
+          { userId: authUserId, eventId: id, interest_level: interestLevel },
+        ]);
+      if (!error) setAlreadySaved(true);
+    },
+    [authUserId, id]
+  );
 
   const handleRemoveEvent = useCallback(async () => {
     const { error } = await supabase
@@ -110,12 +115,21 @@ export default function SingleEvent() {
                 <SaveEventPopup
                   userId={authUserId}
                   handleSaveEvent={handleSaveEvent}
+                  handleRemoveEvent={handleRemoveEvent}
+                  alreadySaved={false}
                 />
               ) : (
-                // <button onClick={handleSaveEvent}>Save Event</button>
-                <button onClick={handleRemoveEvent}>
-                  Remove Event from Profile
-                </button>
+                <div>
+                  <SaveEventPopup
+                    userId={authUserId}
+                    handleSaveEvent={handleSaveEvent}
+                    handleRemoveEvent={handleRemoveEvent}
+                    alreadySaved={true}
+                  />
+                  <button onClick={handleRemoveEvent}>
+                    Remove Event from Profile
+                  </button>
+                </div>
               )
             ) : (
               <p>
@@ -130,3 +144,6 @@ export default function SingleEvent() {
     </div>
   );
 }
+
+// if event is not already saved, show button that lets users save events
+//

--- a/src/Components/SingleEvent/SingleEvent.js
+++ b/src/Components/SingleEvent/SingleEvent.js
@@ -59,7 +59,7 @@ export default function SingleEvent() {
     async (interestLevel) => {
       const { error } = await supabase
         .from("user_added_events")
-        .insert([
+        .upsert([
           { userId: authUserId, eventId: id, interest_level: interestLevel },
         ]);
       if (!error) setAlreadySaved(true);


### PR DESCRIPTION
when saving an event, users:
- see a popup asking them to indicate their interest level in an event (either "interested" or "attending")

implementation notes:
- new "interest_level" column in "user_added_events" table
- .upsert is used to allow users to save new events OR edit their interest level if the event is already saved
- buttons on SingleEvent component change depending on whether or not an event is already saved